### PR TITLE
feat: print welcome message when CLI starts

### DIFF
--- a/boiler_room/main.py
+++ b/boiler_room/main.py
@@ -39,6 +39,8 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    print("Welcome to boiler-room — your AI-powered task runner!")
+
     adapter = build_adapter(args.agent)
     client = GitHubClient(args.project)
     repo_path = os.getcwd()


### PR DESCRIPTION
## Summary

- Adds a welcome message printed to stdout at the start of main() in boiler_room/main.py
- Message appears after parser.parse_args() so --help exits before reaching it
- Message: Welcome to boiler-room your AI-powered task runner!

## Test plan

- boiler-room --help does NOT show the welcome message (argparse exits before the print)
- boiler-room --agent claude --project URL shows the welcome message once before processing starts