### PR TITLE
feat: add --version flag to CLI

### DIFF
--- a/boiler_room/main.py
+++ b/boiler_room/main.py
@@ -26,6 +26,9 @@ def main() -> None:
         description="Pick tasks from a GitHub Project and delegate them to a local AI coding agent."
     )
     parser.add_argument(
+        "--version", action="version", version="boiler-room 0.1.0",
+    )
+    parser.add_argument(
         "--agent", required=True, choices=["claude", "copilot"],
         help="Which AI agent to use",
     )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,6 +5,15 @@ from boiler_room.agents.claude import ClaudeAdapter
 from boiler_room.agents.copilot import CopilotAdapter
 
 
+def test_version_flag(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        with patch("sys.argv", ["boiler-room", "--version"]):
+            main()
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    assert "boiler-room 0.1.0" in captured.out
+
+
 def test_build_adapter_claude():
     assert isinstance(build_adapter("claude"), ClaudeAdapter)
 


### PR DESCRIPTION
## Summary

- Added `--version` flag to `boiler_room/main.py` using `action="version"` with version string `"boiler-room 0.1.0"`
- Running `boiler-room --version` prints `boiler-room 0.1.0` and exits 0
- Added `test_version_flag` test to `tests/test_main.py` that verifies the output and exit code

## Test plan
- [x] `boiler-room --version` prints `boiler-room 0.1.0`
- [x] `test_version_flag` passes in `tests/test_main.py`
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)