### PR TITLE
fix: e2e fixes — permissions, agent prompt, push-before-PR, status updates

### DIFF
--- a/boiler_room/agents/claude.py
+++ b/boiler_room/agents/claude.py
@@ -3,4 +3,4 @@ from boiler_room.agents.base import AgentAdapter
 
 class ClaudeAdapter(AgentAdapter):
     def build_command(self, prompt: str, output_path: str) -> list[str]:
-        return ["claude", "-p", prompt]
+        return ["claude", "-p", prompt, "--dangerously-skip-permissions"]

--- a/boiler_room/agents/copilot.py
+++ b/boiler_room/agents/copilot.py
@@ -3,4 +3,4 @@ from boiler_room.agents.base import AgentAdapter
 
 class CopilotAdapter(AgentAdapter):
     def build_command(self, prompt: str, output_path: str) -> list[str]:
-        return ["copilot", "--prompt", prompt, "--allow-all-tools"]
+        return ["gh", "copilot", "suggest", "-t", "shell", prompt]


### PR DESCRIPTION
## Summary

Fixes discovered during end-to-end testing of the full pipeline. All bugs were caught by running `boiler-room` against a real GitHub Project board with Claude as the agent.

### Fixes already merged to main via fast-forward

- `fix: create_pr uses subprocess stdout instead of unsupported --json flag` — `gh pr create --json url` isn't supported on gh v2.89
- `fix: move task to Done after PR creation, handle existing branches on re-run` — board item never reached Done; `checkout -B` replaces `-b` so retries don't fail
- `fix: use -f flag for optionId to prevent numeric IDs being typed as integer` — all-digit option IDs (e.g. `98236657`) were passed as integers, failing `String!` constraint
- `fix: force-push failure branches, handle 'PR already exists' as success` — retries got rejected; existing PR now treated as success and triggers `move_to_done`
- `fix: prompt now explicitly instructs agent to commit changes before writing output` — agent was making file edits but not committing, leaving no commits on the branch
- `fix: push branch before create_pr so remote has the commits` — `create_pr` ran while branch was local-only; GitHub returned "No commits between main and feature/N"

### This PR (2 commits not yet on main)

- `fix: add --dangerously-skip-permissions so claude agent can write files` — without this flag, `claude -p` subprocess blocks all file writes and can't implement tasks
- `fix: restore CopilotAdapter command changed by agent during e2e run` — the agent helpfully "improved" its own adapter during a run; restored correct `gh copilot suggest` invocation

## Test plan

- [x] 46 unit tests passing
- [x] Full e2e run: task picked from board → Claude implements → branch pushed → PR created → board status → Done

🤖 Generated with [Claude Code](https://claude.com/claude-code)