### PR TITLE
feat: --label filter + e2e test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,97 @@
+# boiler-room
+
+A CLI that picks tasks from a GitHub Project board and delegates them to a local AI coding agent. For each task it prepares a clean git branch, runs the agent, commits the result, and opens a pull request.
+
+## Requirements
+
+- Python 3.10+
+- [`gh` CLI](https://cli.github.com/) authenticated with write access to your repo
+- Claude Code CLI (`claude`) or GitHub Copilot CLI (`gh copilot`) installed and authenticated
+- Run from inside a git repository
+
+## Installation
+
+```bash
+pip install -e .
+```
+
+## Usage
+
+```bash
+boiler-room --agent <agent> --project <project-url> [options]
+```
+
+### Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `--agent` | yes | AI agent to use: `claude` or `copilot` |
+| `--project` | yes | GitHub Project URL, e.g. `https://github.com/users/dznavak/projects/2` |
+| `--count N` | no | Stop after processing N tasks (default: run until queue empty) |
+| `--label LABEL` | no | Only process issues carrying this GitHub label |
+
+### Examples
+
+Process all Todo tasks using Claude:
+
+```bash
+boiler-room --agent claude --project https://github.com/users/dznavak/projects/2
+```
+
+Process at most 3 tasks:
+
+```bash
+boiler-room --agent claude --project https://github.com/users/dznavak/projects/2 --count 3
+```
+
+Process only tasks labeled `sprint-42`:
+
+```bash
+boiler-room --agent claude --project https://github.com/users/dznavak/projects/2 --label sprint-42
+```
+
+## How It Works
+
+For each task in the `Todo` column of the project board (filtered by `--label` if provided):
+
+1. Creates a branch `feature/<issue-number>` from `main`
+2. Moves the task to `In Progress` and applies an `agent-run` label
+3. Runs the agent with the task description as a prompt
+4. If the agent succeeds: pushes the branch and opens a pull request, moves task to `Done`
+5. If the agent fails: pushes the branch for inspection, applies a `failed` label, resets task to `Todo`
+
+The agent writes its results to `.agent-runs/<issue-number>/output.json`:
+
+```json
+{
+  "pr_title": "feat: implement user login",
+  "pr_description": "## What\n...",
+  "summary": "Added JWT auth to /login endpoint",
+  "success": true
+}
+```
+
+## Development
+
+### Run unit tests
+
+```bash
+pytest
+```
+
+### Run the e2e test
+
+The e2e test creates real GitHub issues, runs the full pipeline against the real project board, and verifies all artefacts. It requires `gh` auth and `boiler-room` installed.
+
+```bash
+pytest -m e2e tests/e2e/test_e2e.py -v -s
+```
+
+The test:
+- Generates a UUID-scoped label (`e2e-test-<uuid8>`) to isolate the run
+- Creates 2 trivial issues on the board with that label
+- Runs `boiler-room --agent claude --count 2 --label <label>`
+- Asserts PRs are created, `output.json` is correct, and board items are `Done`
+- Cleans up all created issues, PRs, branches, and the label automatically
+
+The e2e test is excluded from bare `pytest` runs. It takes up to 10 minutes.

--- a/boiler_room/github.py
+++ b/boiler_room/github.py
@@ -71,6 +71,7 @@ query($projectId: ID!) {
               title
               body
               url
+              labels(first: 10) { nodes { name } }
               comments(first: 20) { nodes { body } }
             }
           }
@@ -96,10 +97,11 @@ mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
 
 
 class GitHubClient:
-    def __init__(self, project_url: str):
+    def __init__(self, project_url: str, label: str | None = None):
         self._login, self._project_number = _parse_project_url(project_url)
         self._repo = self._detect_repo()
         self._meta: _ProjectMeta | None = None
+        self._label = label
 
     @staticmethod
     def _detect_repo() -> str:
@@ -155,16 +157,23 @@ class GitHubClient:
         ])
         items = data["data"]["node"]["items"]["nodes"]
         for item in items:
-            if _get_item_status(item) == "Todo" and item.get("content"):
-                content = item["content"]
-                return Task(
-                    id=item["id"],
-                    title=content["title"],
-                    description=content.get("body") or "",
-                    comments=[c["body"] for c in content["comments"]["nodes"]],
-                    issue_number=content["number"],
-                    issue_url=content["url"],
-                )
+            if _get_item_status(item) != "Todo":
+                continue
+            if not item.get("content"):
+                continue
+            content = item["content"]
+            if self._label is not None:
+                labels = [n["name"] for n in content.get("labels", {}).get("nodes", [])]
+                if self._label not in labels:
+                    continue
+            return Task(
+                id=item["id"],
+                title=content["title"],
+                description=content.get("body") or "",
+                comments=[c["body"] for c in content["comments"]["nodes"]],
+                issue_number=content["number"],
+                issue_url=content["url"],
+            )
         return None
 
     def move_to_in_progress(self, item_id: str) -> None:

--- a/boiler_room/github.py
+++ b/boiler_room/github.py
@@ -321,7 +321,10 @@ class GitHubClient:
         )
         if result.returncode != 0:
             return None
-        data = json.loads(result.stdout)
+        try:
+            data = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            return None
         return data[0]["number"] if data else None
 
     def close_issue(self, issue_number: int) -> None:

--- a/boiler_room/github.py
+++ b/boiler_room/github.py
@@ -95,6 +95,45 @@ mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
 }
 """
 
+_ADD_ITEM_MUTATION = """
+mutation($projectId: ID!, $contentId: ID!) {
+  addProjectV2ItemByContentId(input: {
+    projectId: $projectId
+    contentId: $contentId
+  }) {
+    item { id }
+  }
+}
+"""
+
+_REMOVE_ITEM_MUTATION = """
+mutation($projectId: ID!, $itemId: ID!) {
+  deleteProjectV2Item(input: {
+    projectId: $projectId
+    itemId: $itemId
+  }) {
+    deletedItemId
+  }
+}
+"""
+
+_GET_ITEM_STATUS_QUERY = """
+query($itemId: ID!) {
+  node(id: $itemId) {
+    ... on ProjectV2Item {
+      fieldValues(first: 10) {
+        nodes {
+          ... on ProjectV2ItemFieldSingleSelectValue {
+            name
+            field { ... on ProjectV2SingleSelectField { name } }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
 
 class GitHubClient:
     def __init__(self, project_url: str, label: str | None = None):
@@ -221,6 +260,51 @@ class GitHubClient:
         if result.returncode != 0:
             raise GitHubError(result.stderr.strip())
         return result.stdout.strip()
+
+    def create_issue(self, title: str, body: str, label: str) -> int:
+        result = subprocess.run(
+            ["gh", "issue", "create",
+             "--repo", self._repo,
+             "--title", title,
+             "--body", body,
+             "--label", label],
+            capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            raise GitHubError(result.stderr.strip())
+        # stdout is the issue URL, e.g. https://github.com/owner/repo/issues/42
+        return int(result.stdout.strip().rstrip("/").split("/")[-1])
+
+    def add_to_project(self, issue_number: int) -> str:
+        """Add an existing issue to the project board. Returns the project item ID."""
+        meta = self._get_meta()
+        # Step 1: get the issue's global node ID
+        id_result = subprocess.run(
+            ["gh", "api", f"repos/{self._repo}/issues/{issue_number}",
+             "--jq", ".node_id"],
+            capture_output=True, text=True,
+        )
+        if id_result.returncode != 0:
+            raise GitHubError(id_result.stderr.strip())
+        content_id = id_result.stdout.strip()
+        # Step 2: add to project
+        data = _gh_json([
+            "api", "graphql",
+            "-f", f"query={_ADD_ITEM_MUTATION}",
+            "-F", f"projectId={meta.project_id}",
+            "-F", f"contentId={content_id}",
+        ])
+        return data["data"]["addProjectV2ItemByContentId"]["item"]["id"]
+
+    def get_item_status(self, item_id: str) -> str | None:
+        """Return the Status field value for a project board item."""
+        data = _gh_json([
+            "api", "graphql",
+            "-f", f"query={_GET_ITEM_STATUS_QUERY}",
+            "-F", f"itemId={item_id}",
+        ])
+        nodes = data["data"]["node"]["fieldValues"]["nodes"]
+        return _get_item_status({"fieldValues": {"nodes": nodes}})
 
 
 def _parse_project_url(url: str) -> tuple[str, int]:

--- a/boiler_room/github.py
+++ b/boiler_room/github.py
@@ -303,7 +303,10 @@ class GitHubClient:
             "-f", f"query={_GET_ITEM_STATUS_QUERY}",
             "-F", f"itemId={item_id}",
         ])
-        nodes = data["data"]["node"]["fieldValues"]["nodes"]
+        node = data["data"]["node"]
+        if node is None:
+            return None
+        nodes = node["fieldValues"]["nodes"]
         return _get_item_status({"fieldValues": {"nodes": nodes}})
 
 

--- a/boiler_room/github.py
+++ b/boiler_room/github.py
@@ -309,6 +309,49 @@ class GitHubClient:
         nodes = node["fieldValues"]["nodes"]
         return _get_item_status({"fieldValues": {"nodes": nodes}})
 
+    def find_pr_for_branch(self, branch: str) -> int | None:
+        """Return the open PR number for the given head branch, or None."""
+        result = subprocess.run(
+            ["gh", "pr", "list",
+             "--repo", self._repo,
+             "--head", branch,
+             "--state", "open",
+             "--json", "number"],
+            capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            return None
+        data = json.loads(result.stdout)
+        return data[0]["number"] if data else None
+
+    def close_issue(self, issue_number: int) -> None:
+        _gh_run(["issue", "close", str(issue_number), "--repo", self._repo])
+
+    def close_pr(self, pr_number: int) -> None:
+        _gh_run(["pr", "close", str(pr_number), "--repo", self._repo])
+
+    def delete_branch(self, branch: str) -> None:
+        result = subprocess.run(
+            ["gh", "api", "-X", "DELETE",
+             f"repos/{self._repo}/git/refs/heads/{branch}"],
+            capture_output=True, text=True,
+        )
+        # "Reference does not exist" is acceptable — branch was never pushed
+        if result.returncode != 0 and "Reference does not exist" not in result.stderr:
+            raise GitHubError(result.stderr.strip())
+
+    def remove_from_project(self, item_id: str) -> None:
+        meta = self._get_meta()
+        _gh_run([
+            "api", "graphql",
+            "-f", f"query={_REMOVE_ITEM_MUTATION}",
+            "-F", f"projectId={meta.project_id}",
+            "-F", f"itemId={item_id}",
+        ])
+
+    def delete_label(self, label: str) -> None:
+        _gh_run(["label", "delete", label, "--repo", self._repo, "--yes"])
+
 
 def _parse_project_url(url: str) -> tuple[str, int]:
     """Parse a GitHub user project URL.

--- a/boiler_room/main.py
+++ b/boiler_room/main.py
@@ -40,10 +40,14 @@ def main() -> None:
         "--count", type=int, default=None,
         help="Maximum number of tasks to process (default: unlimited)",
     )
+    parser.add_argument(
+        "--label", default=None,
+        help="Only process issues carrying this GitHub label",
+    )
     args = parser.parse_args()
 
     adapter = build_adapter(args.agent)
-    client = GitHubClient(args.project)
+    client = GitHubClient(args.project, label=args.label)
     repo_path = os.getcwd()
 
     processed = 0

--- a/boiler_room/main.py
+++ b/boiler_room/main.py
@@ -26,6 +26,9 @@ def main() -> None:
         description="Pick tasks from a GitHub Project and delegate them to a local AI coding agent."
     )
     parser.add_argument(
+        "--version", action="version", version="boiler-room 0.1.0",
+    )
+    parser.add_argument(
         "--agent", required=True, choices=["claude", "copilot"],
         help="Which AI agent to use",
     )

--- a/docs/superpowers/plans/2026-04-22-e2e-test.md
+++ b/docs/superpowers/plans/2026-04-22-e2e-test.md
@@ -1,0 +1,729 @@
+# E2E Test + Label Filtering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `--label` CLI flag that restricts task pickup to labeled issues, then build a deterministic e2e test that runs the real boiler-room pipeline against a real GitHub project board using a UUID-scoped label.
+
+**Architecture:** Label filtering is added client-side in `GitHubClient.fetch_first_todo_task` after fetching items (GitHub Projects V2 GraphQL has no server-side label filter on items). The e2e test is a pytest module marked `e2e` with a module-scoped fixture that creates/tears down real GitHub issues, project board items, PRs, and branches.
+
+**Tech Stack:** Python 3.10+, pytest, pydantic, `gh` CLI (GitHub CLI), GitHub GraphQL API
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `boiler_room/github.py` | Modify | Add label param + filtering; add 8 new methods for e2e setup/teardown |
+| `boiler_room/main.py` | Modify | Add `--label` CLI arg, pass to `GitHubClient` |
+| `tests/test_github.py` | Modify | Add 2 label-filtering unit tests; add `label` param to `make_client` |
+| `tests/test_main.py` | Modify | Add `--label` arg test |
+| `pyproject.toml` | Modify | Register `e2e` pytest marker; add `tests/e2e` to testpaths |
+| `tests/e2e/__init__.py` | Create | Empty package marker |
+| `tests/e2e/test_e2e.py` | Create | Full e2e fixture + test |
+
+---
+
+## Task 1: Label Filtering in `GitHubClient`
+
+**Files:**
+- Modify: `boiler_room/github.py`
+- Modify: `tests/test_github.py`
+
+- [ ] **Step 1: Write two failing tests**
+
+Open `tests/test_github.py`. Update the `make_client` helper to accept a `label` parameter, then add two new tests at the bottom of the file.
+
+Replace the existing `make_client` function:
+
+```python
+def make_client(label=None):
+    with patch("boiler_room.github.GitHubClient._detect_repo", return_value=REPO):
+        client = GitHubClient(PROJECT_URL, label=label)
+    return client
+```
+
+Add at the bottom of the file:
+
+```python
+@patch("boiler_room.github._gh_json")
+def test_fetch_returns_task_with_matching_label(mock_gh):
+    items_with_label = {
+        "data": {
+            "node": {
+                "items": {
+                    "nodes": [
+                        {
+                            "id": "PVTI_item1",
+                            "fieldValues": {
+                                "nodes": [
+                                    {"name": "Todo", "field": {"name": "Status"}}
+                                ]
+                            },
+                            "content": {
+                                "number": 42,
+                                "title": "Add login",
+                                "body": "As a user...",
+                                "url": "https://github.com/dznavak/my-repo/issues/42",
+                                "labels": {"nodes": [{"name": "my-label"}]},
+                                "comments": {"nodes": []},
+                            },
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    mock_gh.side_effect = [META_RESPONSE, items_with_label]
+    client = make_client(label="my-label")
+    task = client.fetch_first_todo_task()
+    assert task is not None
+    assert task.issue_number == 42
+
+
+@patch("boiler_room.github._gh_json")
+def test_fetch_skips_task_without_matching_label(mock_gh):
+    items_wrong_label = {
+        "data": {
+            "node": {
+                "items": {
+                    "nodes": [
+                        {
+                            "id": "PVTI_item1",
+                            "fieldValues": {
+                                "nodes": [
+                                    {"name": "Todo", "field": {"name": "Status"}}
+                                ]
+                            },
+                            "content": {
+                                "number": 42,
+                                "title": "Add login",
+                                "body": "As a user...",
+                                "url": "https://github.com/dznavak/my-repo/issues/42",
+                                "labels": {"nodes": [{"name": "other-label"}]},
+                                "comments": {"nodes": []},
+                            },
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    mock_gh.side_effect = [META_RESPONSE, items_wrong_label]
+    client = make_client(label="my-label")
+    task = client.fetch_first_todo_task()
+    assert task is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /Users/dzimtrynavak/hack/boiler-room
+pytest tests/test_github.py::test_fetch_returns_task_with_matching_label tests/test_github.py::test_fetch_skips_task_without_matching_label -v
+```
+
+Expected: both FAIL with `TypeError: GitHubClient.__init__() got an unexpected keyword argument 'label'`
+
+- [ ] **Step 3: Update `_FETCH_ITEMS_QUERY` to include labels**
+
+In `boiler_room/github.py`, find `_FETCH_ITEMS_QUERY` and add `labels` inside the `... on Issue` fragment. The updated query constant:
+
+```python
+_FETCH_ITEMS_QUERY = """
+query($projectId: ID!) {
+  node(id: $projectId) {
+    ... on ProjectV2 {
+      items(first: 50, orderBy: {field: POSITION, direction: ASC}) {
+        nodes {
+          id
+          fieldValues(first: 10) {
+            nodes {
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+                field { ... on ProjectV2SingleSelectField { name } }
+              }
+            }
+          }
+          content {
+            ... on Issue {
+              number
+              title
+              body
+              url
+              labels(first: 10) { nodes { name } }
+              comments(first: 20) { nodes { body } }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+```
+
+- [ ] **Step 4: Add `label` param to `GitHubClient.__init__` and filtering to `fetch_first_todo_task`**
+
+In `boiler_room/github.py`, update `GitHubClient.__init__`:
+
+```python
+def __init__(self, project_url: str, label: str | None = None):
+    self._login, self._project_number = _parse_project_url(project_url)
+    self._repo = self._detect_repo()
+    self._meta: _ProjectMeta | None = None
+    self._label = label
+```
+
+Update `fetch_first_todo_task`:
+
+```python
+def fetch_first_todo_task(self) -> Task | None:
+    meta = self._get_meta()
+    data = _gh_json([
+        "api", "graphql",
+        "-f", f"query={_FETCH_ITEMS_QUERY}",
+        "-F", f"projectId={meta.project_id}",
+    ])
+    items = data["data"]["node"]["items"]["nodes"]
+    for item in items:
+        if _get_item_status(item) != "Todo":
+            continue
+        if not item.get("content"):
+            continue
+        content = item["content"]
+        if self._label is not None:
+            labels = [n["name"] for n in content.get("labels", {}).get("nodes", [])]
+            if self._label not in labels:
+                continue
+        return Task(
+            id=item["id"],
+            title=content["title"],
+            description=content.get("body") or "",
+            comments=[c["body"] for c in content["comments"]["nodes"]],
+            issue_number=content["number"],
+            issue_url=content["url"],
+        )
+    return None
+```
+
+- [ ] **Step 5: Run all GitHub tests to verify passing**
+
+```bash
+pytest tests/test_github.py -v
+```
+
+Expected: all tests PASS (including the two new ones and all existing ones — existing `ITEMS_RESPONSE` fixture has no `labels` key, which is handled safely by `.get("labels", {}).get("nodes", [])` when `self._label is None`)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add boiler_room/github.py tests/test_github.py
+git commit -m "feat: add --label filtering to fetch_first_todo_task"
+```
+
+---
+
+## Task 2: `--label` CLI Argument
+
+**Files:**
+- Modify: `boiler_room/main.py`
+- Modify: `tests/test_main.py`
+
+- [ ] **Step 1: Write failing test**
+
+Add at the bottom of `tests/test_main.py`:
+
+```python
+@patch("boiler_room.main.run_one_task")
+@patch("boiler_room.main.GitHubClient")
+def test_main_passes_label_to_client(mock_client_cls, mock_run):
+    mock_run.return_value = False
+    with patch("sys.argv", [
+        "boiler-room",
+        "--agent", "claude",
+        "--project", "https://github.com/users/x/projects/1",
+        "--label", "e2e-test-abc",
+    ]):
+        main()
+    mock_client_cls.assert_called_once_with(
+        "https://github.com/users/x/projects/1", label="e2e-test-abc"
+    )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest tests/test_main.py::test_main_passes_label_to_client -v
+```
+
+Expected: FAIL — `AssertionError: expected call not found` (GitHubClient is called without `label=`)
+
+- [ ] **Step 3: Add `--label` arg to `main.py` and pass to `GitHubClient`**
+
+In `boiler_room/main.py`, add the argument after `--count`:
+
+```python
+parser.add_argument(
+    "--label", default=None,
+    help="Only process issues carrying this GitHub label",
+)
+```
+
+Update the `GitHubClient` instantiation:
+
+```python
+client = GitHubClient(args.project, label=args.label)
+```
+
+- [ ] **Step 4: Run all main tests**
+
+```bash
+pytest tests/test_main.py -v
+```
+
+Expected: all tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add boiler_room/main.py tests/test_main.py
+git commit -m "feat: add --label CLI arg to filter tasks by GitHub label"
+```
+
+---
+
+## Task 3: GitHubClient — Setup Methods
+
+These methods are used by the e2e fixture to create issues and add them to the project board.
+
+**Files:**
+- Modify: `boiler_room/github.py`
+
+- [ ] **Step 1: Add GraphQL mutations and `create_issue` method**
+
+Add these constants after `_UPDATE_STATUS_MUTATION` in `boiler_room/github.py`:
+
+```python
+_ADD_ITEM_MUTATION = """
+mutation($projectId: ID!, $contentId: ID!) {
+  addProjectV2ItemByContentId(input: {
+    projectId: $projectId
+    contentId: $contentId
+  }) {
+    item { id }
+  }
+}
+"""
+
+_REMOVE_ITEM_MUTATION = """
+mutation($projectId: ID!, $itemId: ID!) {
+  deleteProjectV2Item(input: {
+    projectId: $projectId
+    itemId: $itemId
+  }) {
+    deletedItemId
+  }
+}
+"""
+
+_GET_ITEM_STATUS_QUERY = """
+query($itemId: ID!) {
+  node(id: $itemId) {
+    ... on ProjectV2Item {
+      fieldValues(first: 10) {
+        nodes {
+          ... on ProjectV2ItemFieldSingleSelectValue {
+            name
+            field { ... on ProjectV2SingleSelectField { name } }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+```
+
+Add these methods to the `GitHubClient` class, after `create_pr`:
+
+```python
+def create_issue(self, title: str, body: str, label: str) -> int:
+    result = subprocess.run(
+        ["gh", "issue", "create",
+         "--repo", self._repo,
+         "--title", title,
+         "--body", body,
+         "--label", label],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise GitHubError(result.stderr.strip())
+    # stdout is the issue URL, e.g. https://github.com/owner/repo/issues/42
+    return int(result.stdout.strip().rstrip("/").split("/")[-1])
+
+def add_to_project(self, issue_number: int) -> str:
+    """Add an existing issue to the project board. Returns the project item ID."""
+    meta = self._get_meta()
+    # Step 1: get the issue's global node ID
+    id_result = subprocess.run(
+        ["gh", "api", f"repos/{self._repo}/issues/{issue_number}",
+         "--jq", ".node_id"],
+        capture_output=True, text=True,
+    )
+    if id_result.returncode != 0:
+        raise GitHubError(id_result.stderr.strip())
+    content_id = id_result.stdout.strip()
+    # Step 2: add to project
+    data = _gh_json([
+        "api", "graphql",
+        "-f", f"query={_ADD_ITEM_MUTATION}",
+        "-F", f"projectId={meta.project_id}",
+        "-F", f"contentId={content_id}",
+    ])
+    return data["data"]["addProjectV2ItemByContentId"]["item"]["id"]
+
+def get_item_status(self, item_id: str) -> str | None:
+    """Return the Status field value for a project board item."""
+    data = _gh_json([
+        "api", "graphql",
+        "-f", f"query={_GET_ITEM_STATUS_QUERY}",
+        "-F", f"itemId={item_id}",
+    ])
+    nodes = data["data"]["node"]["fieldValues"]["nodes"]
+    return _get_item_status({"fieldValues": {"nodes": nodes}})
+```
+
+- [ ] **Step 2: Run existing tests to ensure nothing is broken**
+
+```bash
+pytest tests/test_github.py tests/test_main.py -v
+```
+
+Expected: all tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add boiler_room/github.py
+git commit -m "feat: add create_issue, add_to_project, get_item_status to GitHubClient"
+```
+
+---
+
+## Task 4: GitHubClient — Teardown Methods
+
+**Files:**
+- Modify: `boiler_room/github.py`
+
+- [ ] **Step 1: Add teardown methods to `GitHubClient`**
+
+Add these methods to `GitHubClient` after `get_item_status`:
+
+```python
+def find_pr_for_branch(self, branch: str) -> int | None:
+    """Return the open PR number for the given head branch, or None."""
+    result = subprocess.run(
+        ["gh", "pr", "list",
+         "--repo", self._repo,
+         "--head", branch,
+         "--state", "open",
+         "--json", "number"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        return None
+    data = json.loads(result.stdout)
+    return data[0]["number"] if data else None
+
+def close_issue(self, issue_number: int) -> None:
+    _gh_run(["issue", "close", str(issue_number), "--repo", self._repo])
+
+def close_pr(self, pr_number: int) -> None:
+    _gh_run(["pr", "close", str(pr_number), "--repo", self._repo])
+
+def delete_branch(self, branch: str) -> None:
+    result = subprocess.run(
+        ["gh", "api", "-X", "DELETE",
+         f"repos/{self._repo}/git/refs/heads/{branch}"],
+        capture_output=True, text=True,
+    )
+    # "Reference does not exist" is acceptable — branch was never pushed
+    if result.returncode != 0 and "Reference does not exist" not in result.stderr:
+        raise GitHubError(result.stderr.strip())
+
+def remove_from_project(self, item_id: str) -> None:
+    meta = self._get_meta()
+    _gh_run([
+        "api", "graphql",
+        "-f", f"query={_REMOVE_ITEM_MUTATION}",
+        "-F", f"projectId={meta.project_id}",
+        "-F", f"itemId={item_id}",
+    ])
+
+def delete_label(self, label: str) -> None:
+    _gh_run(["label", "delete", label, "--repo", self._repo, "--yes"])
+```
+
+- [ ] **Step 2: Run existing tests**
+
+```bash
+pytest tests/ -v --ignore=tests/e2e
+```
+
+Expected: all tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add boiler_room/github.py
+git commit -m "feat: add teardown methods to GitHubClient (close_issue, close_pr, delete_branch, remove_from_project, delete_label, find_pr_for_branch)"
+```
+
+---
+
+## Task 5: E2E Test — Marker, Fixture, and Test Body
+
+**Files:**
+- Modify: `pyproject.toml`
+- Create: `tests/e2e/__init__.py`
+- Create: `tests/e2e/test_e2e.py`
+
+- [ ] **Step 1: Register e2e marker in `pyproject.toml`**
+
+Replace the `[tool.pytest.ini_options]` section in `pyproject.toml`:
+
+```toml
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+markers = [
+    "e2e: end-to-end tests against real GitHub (slow, requires gh auth) -- run with: pytest -m e2e",
+]
+```
+
+- [ ] **Step 2: Create `tests/e2e/__init__.py`**
+
+Create an empty file at `tests/e2e/__init__.py`.
+
+- [ ] **Step 3: Create `tests/e2e/test_e2e.py`**
+
+```python
+"""
+End-to-end test for the boiler-room pipeline.
+
+Creates real GitHub issues on a real project board, runs the CLI, and asserts
+that the full pipeline produced the expected artefacts. Acts as living
+documentation of what the system guarantees on every successful run.
+
+Run with:
+    pytest -m e2e tests/e2e/test_e2e.py -v -s
+
+Requirements:
+    - `gh` CLI authenticated with write access to the repo
+    - `boiler-room` installed in the current Python environment (`pip install -e .`)
+    - The GitHub project at PROJECT_URL must have Todo / In Progress / Done columns
+"""
+
+import json
+import os
+import subprocess
+import uuid
+from dataclasses import dataclass, field
+
+import pytest
+
+from boiler_room.github import GitHubClient
+from boiler_room.models import AgentOutput
+
+PROJECT_URL = "https://github.com/users/dznavak/projects/2"
+
+_TASK_SPECS = [
+    {
+        "title": "Create file hello.txt",
+        "body": (
+            "Create a file named hello.txt in the repo root "
+            "containing the text 'Hello World'"
+        ),
+    },
+    {
+        "title": "Create file goodbye.txt",
+        "body": (
+            "Create a file named goodbye.txt in the repo root "
+            "containing the text 'Goodbye World'"
+        ),
+    },
+]
+
+
+@dataclass
+class _E2EItem:
+    issue_number: int
+    item_id: str
+    branch: str
+
+
+@dataclass
+class _E2EContext:
+    label: str
+    items: list[_E2EItem] = field(default_factory=list)
+    client: GitHubClient = None
+
+
+@pytest.fixture(scope="module")
+def e2e_context():
+    run_id = str(uuid.uuid4())[:8]
+    label = f"e2e-test-{run_id}"
+    client = GitHubClient(PROJECT_URL, label=label)
+
+    ctx = _E2EContext(label=label, client=client)
+
+    client.ensure_label(label)
+
+    try:
+        for spec in _TASK_SPECS:
+            issue_number = client.create_issue(spec["title"], spec["body"], label)
+            item_id = client.add_to_project(issue_number)
+            client.move_to_todo(item_id)
+            ctx.items.append(_E2EItem(
+                issue_number=issue_number,
+                item_id=item_id,
+                branch=f"feature/{issue_number}",
+            ))
+
+        yield ctx
+
+    finally:
+        for item in ctx.items:
+            pr_number = client.find_pr_for_branch(item.branch)
+            if pr_number is not None:
+                try:
+                    client.close_pr(pr_number)
+                except Exception:
+                    pass
+            try:
+                client.delete_branch(item.branch)
+            except Exception:
+                pass
+            try:
+                client.close_issue(item.issue_number)
+            except Exception:
+                pass
+            try:
+                client.remove_from_project(item.item_id)
+            except Exception:
+                pass
+        try:
+            client.delete_label(label)
+        except Exception:
+            pass
+
+
+@pytest.mark.e2e
+def test_pipeline_processes_labeled_tasks(e2e_context):
+    """
+    Full pipeline run: boiler-room picks up the two e2e-labeled tasks,
+    delegates them to claude, commits code, opens PRs, and marks both Done.
+    """
+    ctx = e2e_context
+
+    # --- Run the CLI ---
+    result = subprocess.run(
+        [
+            "boiler-room",
+            "--agent", "claude",
+            "--project", PROJECT_URL,
+            "--count", "2",
+            "--label", ctx.label,
+        ],
+        timeout=600,
+    )
+    assert result.returncode == 0, (
+        f"boiler-room exited with code {result.returncode}"
+    )
+
+    # --- Assert output artefacts ---
+    for item in ctx.items:
+        output_path = os.path.join(
+            ".agent-runs", str(item.issue_number), "output.json"
+        )
+        assert os.path.exists(output_path), (
+            f"output.json missing for issue #{item.issue_number} at {output_path}"
+        )
+        with open(output_path) as f:
+            raw = json.load(f)
+        output = AgentOutput(**raw)
+
+        assert output.success is True, (
+            f"Agent reported success=False for issue #{item.issue_number}. "
+            f"summary: {output.summary!r}"
+        )
+        assert output.pr_title, (
+            f"pr_title is empty for issue #{item.issue_number}"
+        )
+        assert output.pr_description, (
+            f"pr_description is empty for issue #{item.issue_number}"
+        )
+
+    # --- Assert PRs were created ---
+    for item in ctx.items:
+        pr_number = ctx.client.find_pr_for_branch(item.branch)
+        assert pr_number is not None, (
+            f"No open PR found for branch {item.branch!r} (issue #{item.issue_number})"
+        )
+
+    # --- Assert project board items are Done ---
+    for item in ctx.items:
+        status = ctx.client.get_item_status(item.item_id)
+        assert status == "Done", (
+            f"Project item {item.item_id} (issue #{item.issue_number}) "
+            f"expected status 'Done', got {status!r}"
+        )
+```
+
+- [ ] **Step 4: Verify test collection (dry run — no real GitHub calls)**
+
+```bash
+pytest -m e2e tests/e2e/test_e2e.py --collect-only
+```
+
+Expected output contains:
+```
+<Module tests/e2e/test_e2e.py>
+  <Function test_pipeline_processes_labeled_tasks>
+```
+
+- [ ] **Step 5: Verify normal test run still excludes e2e**
+
+```bash
+pytest tests/ --ignore=tests/e2e -v
+```
+
+Expected: all existing unit tests PASS, no e2e tests collected
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pyproject.toml tests/e2e/__init__.py tests/e2e/test_e2e.py
+git commit -m "feat: add e2e test with UUID-scoped label isolation and automatic cleanup"
+```
+
+---
+
+## Running the E2E Test
+
+After all tasks are complete:
+
+```bash
+pytest -m e2e tests/e2e/test_e2e.py -v -s
+```
+
+The test takes up to 10 minutes (claude agent runtime). Expected output:
+
+```
+PASSED tests/e2e/test_e2e.py::test_pipeline_processes_labeled_tasks
+```
+
+If it fails once due to agent flakiness, rerun:
+
+```bash
+pytest -m e2e tests/e2e/test_e2e.py -v -s
+```

--- a/docs/superpowers/specs/2026-04-22-e2e-test-design.md
+++ b/docs/superpowers/specs/2026-04-22-e2e-test-design.md
@@ -1,0 +1,176 @@
+# E2E Test + Label Filtering — Design Spec
+
+**Date:** 2026-04-22
+**Status:** Approved
+
+## Overview
+
+Two related pieces of work:
+
+1. **`--label` flag** — a new CLI argument that restricts task pickup to issues carrying a specific GitHub label, enabling targeted runs (and isolated test runs).
+2. **E2E test** — a deterministic end-to-end test that runs the real boiler-room pipeline against the real GitHub project, using a UUID-scoped label to avoid cross-run interference. Acts as living documentation of the system's expected behaviour and artefacts.
+
+---
+
+## Part 1: `--label` Feature
+
+### CLI
+
+```
+boiler-room --agent claude --project <url> --label e2e-test-abc123
+```
+
+`--label` is optional. When omitted, behaviour is unchanged (all Todo tasks are picked up).
+
+### Changes
+
+**`main.py`**
+- Add `--label` optional argument.
+- Pass it to `GitHubClient(project_url, label=label)`.
+
+**`github.py` — `_FETCH_ITEMS_QUERY`**
+
+Add inside the `... on Issue` fragment:
+
+```graphql
+labels(first: 10) {
+  nodes { name }
+}
+```
+
+**`github.py` — `GitHubClient`**
+
+- `__init__` gains `label: str | None = None`, stored as `self._label`.
+- `fetch_first_todo_task()` — after checking `status == "Todo"`, additionally checks that the issue's labels contain `self._label` (if set). Issues not carrying the label are skipped silently.
+
+### Unit tests (additions to `test_github.py`)
+
+- `test_fetch_returns_labeled_task` — item has matching label → returned.
+- `test_fetch_skips_unlabeled_task` — item lacks the label → `None` returned.
+
+---
+
+## Part 2: E2E Test
+
+### Location
+
+```
+tests/e2e/__init__.py
+tests/e2e/test_e2e.py
+```
+
+Marked `@pytest.mark.e2e`. Not included in default `pytest` runs. Registered in `pyproject.toml`:
+
+```toml
+[tool.pytest.ini_options]
+markers = ["e2e: end-to-end tests against real GitHub (slow, requires gh auth)"]
+```
+
+### Run command
+
+```bash
+pytest -m e2e tests/e2e/test_e2e.py -v -s
+```
+
+### Test tasks
+
+Two trivially simple GitHub issues created fresh per run:
+
+| # | Title | Body |
+|---|-------|------|
+| 1 | `Create file hello.txt` | `Create a file named hello.txt in the repo root containing the text 'Hello World'` |
+| 2 | `Create file goodbye.txt` | `Create a file named goodbye.txt in the repo root containing the text 'Goodbye World'` |
+
+Both issues are labeled `e2e-test-<uuid4[:8]>` and added to the project board in `Todo` status.
+
+### Fixture (`scope="module"`)
+
+```
+generate run_id = uuid4()[:8]
+label = f"e2e-test-{run_id}"
+
+client.ensure_label(label)
+
+for each task_spec:
+    issue_number = client.create_issue(title, body, label)
+    item_id = client.add_to_project(issue_number)
+    client.set_item_status_todo(item_id)
+
+yield RunContext(label, items, client)
+
+# teardown (always runs):
+for each item:
+    client.close_issue(issue_number)
+    client.close_pr(pr_number)          # find by branch feature/<issue_number>
+    client.delete_branch(branch)
+    client.remove_from_project(item_id)
+client.delete_label(label)
+```
+
+Teardown is registered before yield so it runs even if the test body raises.
+
+### Test body assertions
+
+1. Run CLI as subprocess:
+   ```python
+   result = subprocess.run(
+       ["boiler-room", "--agent", "claude",
+        "--project", PROJECT_URL,
+        "--count", "2",
+        "--label", label],
+       timeout=600,
+   )
+   assert result.returncode == 0
+   ```
+
+2. For each issue — `output.json` structure:
+   ```python
+   output = AgentOutput(**json.load(open(f".agent-runs/{issue_number}/output.json")))
+   assert output.success is True
+   assert output.pr_title        # non-empty
+   assert output.pr_description  # non-empty
+   ```
+
+3. For each issue — PR exists:
+   ```python
+   # gh pr list --head feature/<issue_number> --state open --json number
+   assert len(prs) == 1
+   ```
+
+4. Project board status — both items in `Done`:
+   ```python
+   # re-fetch items via GraphQL, check status field == "Done"
+   ```
+
+### New `GitHubClient` methods
+
+| Method | Implementation |
+|--------|---------------|
+| `create_issue(title, body, label) -> int` | `gh issue create`, returns issue number |
+| `add_to_project(issue_number) -> str` | fetch issue node_id via REST, then `addProjectV2ItemByContentId` mutation; returns project item ID |
+| `set_item_status_todo(item_id)` | calls existing `_update_status` with `todo_option_id` |
+| `close_issue(issue_number)` | `gh issue close` |
+| `close_pr(pr_number)` | `gh pr close` |
+| `delete_branch(branch)` | `gh api -X DELETE repos/{repo}/git/refs/heads/{branch}` |
+| `remove_from_project(item_id)` | `deleteProjectV2Item` GraphQL mutation |
+| `delete_label(label)` | `gh label delete --yes` |
+| `find_pr_for_branch(branch) -> int \| None` | `gh pr list --head {branch} --json number` |
+
+### `add_to_project` detail
+
+Two steps inside one method:
+1. `gh api repos/{repo}/issues/{number} --jq .node_id` → `issue_node_id`
+2. GraphQL mutation `addProjectV2ItemByContentId(input: { projectId, contentId: issue_node_id })` → returns `item.id`
+
+### Flakiness posture
+
+The tasks are intentionally trivial so the claude agent succeeds in effectively every run. The test is marked `e2e` and excluded from CI by default. Rerunning manually after a rare failure is acceptable — no in-test retry loop.
+
+---
+
+## Scope
+
+Not in scope:
+- Testing the `copilot` agent path.
+- Org-owned project boards (user board only).
+- Parallel e2e runs (UUID label isolates them, but sequential is assumed).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ boiler-room = "boiler_room.main:main"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+addopts = "-m 'not e2e'"
 markers = [
     "e2e: end-to-end tests against real GitHub (slow, requires gh auth) -- run with: pytest -m e2e",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ boiler-room = "boiler_room.main:main"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "e2e: end-to-end tests against real GitHub (slow, requires gh auth) -- run with: pytest -m e2e",
+]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -1,0 +1,170 @@
+"""
+End-to-end test for the boiler-room pipeline.
+
+Creates real GitHub issues on a real project board, runs the CLI, and asserts
+that the full pipeline produced the expected artefacts. Acts as living
+documentation of what the system guarantees on every successful run.
+
+Run with:
+    pytest -m e2e tests/e2e/test_e2e.py -v -s
+
+Requirements:
+    - `gh` CLI authenticated with write access to the repo
+    - `boiler-room` installed in the current Python environment (`pip install -e .`)
+    - The GitHub project at PROJECT_URL must have Todo / In Progress / Done columns
+"""
+
+import json
+import os
+import subprocess
+import uuid
+from dataclasses import dataclass, field
+
+import pytest
+
+from boiler_room.github import GitHubClient
+from boiler_room.models import AgentOutput
+
+PROJECT_URL = "https://github.com/users/dznavak/projects/2"
+
+_TASK_SPECS = [
+    {
+        "title": "Create file hello.txt",
+        "body": (
+            "Create a file named hello.txt in the repo root "
+            "containing the text 'Hello World'"
+        ),
+    },
+    {
+        "title": "Create file goodbye.txt",
+        "body": (
+            "Create a file named goodbye.txt in the repo root "
+            "containing the text 'Goodbye World'"
+        ),
+    },
+]
+
+
+@dataclass
+class _E2EItem:
+    issue_number: int
+    item_id: str
+    branch: str
+
+
+@dataclass
+class _E2EContext:
+    label: str
+    items: list[_E2EItem] = field(default_factory=list)
+    client: GitHubClient = None
+
+
+@pytest.fixture(scope="module")
+def e2e_context():
+    run_id = str(uuid.uuid4())[:8]
+    label = f"e2e-test-{run_id}"
+    client = GitHubClient(PROJECT_URL, label=label)
+
+    ctx = _E2EContext(label=label, client=client)
+
+    client.ensure_label(label)
+
+    try:
+        for spec in _TASK_SPECS:
+            issue_number = client.create_issue(spec["title"], spec["body"], label)
+            item_id = client.add_to_project(issue_number)
+            client.move_to_todo(item_id)
+            ctx.items.append(_E2EItem(
+                issue_number=issue_number,
+                item_id=item_id,
+                branch=f"feature/{issue_number}",
+            ))
+
+        yield ctx
+
+    finally:
+        for item in ctx.items:
+            pr_number = client.find_pr_for_branch(item.branch)
+            if pr_number is not None:
+                try:
+                    client.close_pr(pr_number)
+                except Exception:
+                    pass
+            try:
+                client.delete_branch(item.branch)
+            except Exception:
+                pass
+            try:
+                client.close_issue(item.issue_number)
+            except Exception:
+                pass
+            try:
+                client.remove_from_project(item.item_id)
+            except Exception:
+                pass
+        try:
+            client.delete_label(label)
+        except Exception:
+            pass
+
+
+@pytest.mark.e2e
+def test_pipeline_processes_labeled_tasks(e2e_context):
+    """
+    Full pipeline run: boiler-room picks up the two e2e-labeled tasks,
+    delegates them to claude, commits code, opens PRs, and marks both Done.
+    """
+    ctx = e2e_context
+
+    # --- Run the CLI ---
+    result = subprocess.run(
+        [
+            "boiler-room",
+            "--agent", "claude",
+            "--project", PROJECT_URL,
+            "--count", "2",
+            "--label", ctx.label,
+        ],
+        timeout=600,
+    )
+    assert result.returncode == 0, (
+        f"boiler-room exited with code {result.returncode}"
+    )
+
+    # --- Assert output artefacts ---
+    for item in ctx.items:
+        output_path = os.path.join(
+            ".agent-runs", str(item.issue_number), "output.json"
+        )
+        assert os.path.exists(output_path), (
+            f"output.json missing for issue #{item.issue_number} at {output_path}"
+        )
+        with open(output_path) as f:
+            raw = json.load(f)
+        output = AgentOutput(**raw)
+
+        assert output.success is True, (
+            f"Agent reported success=False for issue #{item.issue_number}. "
+            f"summary: {output.summary!r}"
+        )
+        assert output.pr_title, (
+            f"pr_title is empty for issue #{item.issue_number}"
+        )
+        assert output.pr_description, (
+            f"pr_description is empty for issue #{item.issue_number}"
+        )
+
+    # --- Assert PRs were created ---
+    for item in ctx.items:
+        pr_number = ctx.client.find_pr_for_branch(item.branch)
+        assert pr_number is not None, (
+            f"No open PR found for branch {item.branch!r} (issue #{item.issue_number})"
+        )
+
+    # --- Assert project board items are Done ---
+    for item in ctx.items:
+        status = ctx.client.get_item_status(item.item_id)
+        assert status == "Done", (
+            f"Project item {item.item_id} (issue #{item.issue_number}) "
+            f"expected status 'Done', got {status!r}"
+        )

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -126,9 +126,13 @@ def test_pipeline_processes_labeled_tasks(e2e_context):
             "--label", ctx.label,
         ],
         timeout=600,
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 0, (
-        f"boiler-room exited with code {result.returncode}"
+        f"boiler-room exited with code {result.returncode}\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
     )
 
     # --- Assert output artefacts ---

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -56,7 +56,7 @@ class _E2EItem:
 class _E2EContext:
     label: str
     items: list[_E2EItem] = field(default_factory=list)
-    client: GitHubClient = None
+    client: GitHubClient | None = None
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -63,9 +63,9 @@ def _prebuild_meta():
     )
 
 
-def make_client():
+def make_client(label=None):
     with patch("boiler_room.github.GitHubClient._detect_repo", return_value=REPO):
-        client = GitHubClient(PROJECT_URL)
+        client = GitHubClient(PROJECT_URL, label=label)
     return client
 
 
@@ -191,3 +191,72 @@ def test_parse_project_url_org_raises():
 def test_parse_project_url_malformed_raises():
     with pytest.raises(GitHubError):
         _parse_project_url("https://github.com/projects/1")
+
+
+@patch("boiler_room.github._gh_json")
+def test_fetch_returns_task_with_matching_label(mock_gh):
+    items_with_label = {
+        "data": {
+            "node": {
+                "items": {
+                    "nodes": [
+                        {
+                            "id": "PVTI_item1",
+                            "fieldValues": {
+                                "nodes": [
+                                    {"name": "Todo", "field": {"name": "Status"}}
+                                ]
+                            },
+                            "content": {
+                                "number": 42,
+                                "title": "Add login",
+                                "body": "As a user...",
+                                "url": "https://github.com/dznavak/my-repo/issues/42",
+                                "labels": {"nodes": [{"name": "my-label"}]},
+                                "comments": {"nodes": []},
+                            },
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    mock_gh.side_effect = [META_RESPONSE, items_with_label]
+    client = make_client(label="my-label")
+    task = client.fetch_first_todo_task()
+    assert task is not None
+    assert task.issue_number == 42
+
+
+@patch("boiler_room.github._gh_json")
+def test_fetch_skips_task_without_matching_label(mock_gh):
+    items_wrong_label = {
+        "data": {
+            "node": {
+                "items": {
+                    "nodes": [
+                        {
+                            "id": "PVTI_item1",
+                            "fieldValues": {
+                                "nodes": [
+                                    {"name": "Todo", "field": {"name": "Status"}}
+                                ]
+                            },
+                            "content": {
+                                "number": 42,
+                                "title": "Add login",
+                                "body": "As a user...",
+                                "url": "https://github.com/dznavak/my-repo/issues/42",
+                                "labels": {"nodes": [{"name": "other-label"}]},
+                                "comments": {"nodes": []},
+                            },
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    mock_gh.side_effect = [META_RESPONSE, items_wrong_label]
+    client = make_client(label="my-label")
+    task = client.fetch_first_todo_task()
+    assert task is None

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -260,3 +260,12 @@ def test_fetch_skips_task_without_matching_label(mock_gh):
     client = make_client(label="my-label")
     task = client.fetch_first_todo_task()
     assert task is None
+
+
+@patch("boiler_room.github._gh_json")
+def test_fetch_skips_task_with_no_labels_key_when_label_filter_set(mock_gh):
+    # ITEMS_RESPONSE has no 'labels' key in content — should be skipped when label filter is active
+    mock_gh.side_effect = [META_RESPONSE, ITEMS_RESPONSE]
+    client = make_client(label="my-label")
+    task = client.fetch_first_todo_task()
+    assert task is None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -52,3 +52,19 @@ def test_main_stops_after_count(mock_client_cls, mock_run):
     ]):
         main()
     assert mock_run.call_count == 2
+
+
+@patch("boiler_room.main.run_one_task")
+@patch("boiler_room.main.GitHubClient")
+def test_main_passes_label_to_client(mock_client_cls, mock_run):
+    mock_run.return_value = False
+    with patch("sys.argv", [
+        "boiler-room",
+        "--agent", "claude",
+        "--project", "https://github.com/users/x/projects/1",
+        "--label", "e2e-test-abc",
+    ]):
+        main()
+    mock_client_cls.assert_called_once_with(
+        "https://github.com/users/x/projects/1", label="e2e-test-abc"
+    )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,6 +5,15 @@ from boiler_room.agents.claude import ClaudeAdapter
 from boiler_room.agents.copilot import CopilotAdapter
 
 
+def test_version_flag(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        with patch("sys.argv", ["boiler-room", "--version"]):
+            main()
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    assert "boiler-room 0.1.0" in captured.out
+
+
 def test_build_adapter_claude():
     assert isinstance(build_adapter("claude"), ClaudeAdapter)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -52,6 +52,9 @@ def test_main_stops_after_count(mock_client_cls, mock_run):
     ]):
         main()
     assert mock_run.call_count == 2
+    mock_client_cls.assert_called_once_with(
+        "https://github.com/users/x/projects/1", label=None
+    )
 
 
 @patch("boiler_room.main.run_one_task")


### PR DESCRIPTION
## Summary

- Adds `--label` CLI flag to restrict task pickup to issues carrying a specific GitHub label
- Adds 9 new `GitHubClient` methods for e2e setup/teardown (create issues, manage project board items, close PRs/branches/labels)
- Adds deterministic e2e test that runs the real pipeline against the real GitHub project board with UUID-scoped label isolation and automatic cleanup

## New CLI usage

```bash
# Only process issues labeled 'sprint-42'
boiler-room --agent claude --project https://github.com/users/dznavak/projects/2 --label sprint-42
```

## Run the e2e test

```bash
pytest -m e2e tests/e2e/test_e2e.py -v -s
```

Creates 2 real issues, runs boiler-room with Claude, asserts PRs created + board items Done, cleans up everything automatically.

## Test plan

- [ ] `pytest` — all unit tests pass (e2e auto-excluded)
- [ ] `pytest -m e2e tests/e2e/test_e2e.py -v -s` — full pipeline run succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)