### PR TITLE
Print welcome message when boiler-room CLI starts

### DIFF
--- a/boiler_room/main.py
+++ b/boiler_room/main.py
@@ -46,6 +46,8 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    print("Welcome to boiler-room — your AI-powered task runner!")
+
     adapter = build_adapter(args.agent)
     client = GitHubClient(args.project, label=args.label)
     repo_path = os.getcwd()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -29,6 +29,28 @@ def test_build_adapter_unknown_exits():
 
 @patch("boiler_room.main.run_one_task")
 @patch("boiler_room.main.GitHubClient")
+def test_main_prints_welcome_message(mock_client_cls, mock_run, capsys):
+    mock_run.return_value = False
+    with patch("sys.argv", [
+        "boiler-room",
+        "--agent", "claude",
+        "--project", "https://github.com/users/x/projects/1",
+    ]):
+        main()
+    captured = capsys.readouterr()
+    assert "Welcome to boiler-room" in captured.out
+
+
+def test_help_does_not_print_welcome(capsys):
+    with pytest.raises(SystemExit):
+        with patch("sys.argv", ["boiler-room", "--help"]):
+            main()
+    captured = capsys.readouterr()
+    assert "Welcome to boiler-room" not in captured.out
+
+
+@patch("boiler_room.main.run_one_task")
+@patch("boiler_room.main.GitHubClient")
 def test_main_loops_until_queue_empty(mock_client_cls, mock_run):
     mock_run.side_effect = [True, True, False]  # 2 tasks then empty
     with patch("sys.argv", [


### PR DESCRIPTION
## Summary

Adds a friendly welcome message printed to stdout when the `boiler-room` CLI starts an actual run.

## Changes

- **`boiler_room/main.py`**: Added `print("Welcome to boiler-room — your AI-powered task runner!")` in `main()` after `args = parser.parse_args()`, so it only runs during real invocations (not `--help` or `--version`).
- **`tests/test_main.py`**: Added two new tests:
  - `test_main_prints_welcome_message` — verifies the message appears on stdout during a normal run.
  - `test_help_does_not_print_welcome` — verifies the message is absent when `--help` is passed.

## Acceptance criteria

- ✅ `boiler-room --help` does NOT show the welcome message
- ✅ `boiler-room --agent claude --project <url>` shows the welcome message once before processing starts